### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - 🚀 I have experience with **Python and iOS Engineering**.
 - 👀 I’m interested in **Aerospace, Cyber Security, Electric Vehicles, and Cryptocurrency**.
-- 👨‍💻 I've worked on **[Lure Cast](www.lurecastapp.com), [Ripple](www.rippleapp.com), [BBA Mobile](https://www.burrburton.org), and more**.
+- 👨‍💻 I've worked on **[Lure Cast](//www.lurecastapp.com), [Ripple](//www.rippleapp.com), [BBA Mobile](https://www.burrburton.org), and more**.
 - 📫 Where to reach me:
     
     [<img alt="LinkedIn Logo" height="30" src="https://user-images.githubusercontent.com/59615799/163059735-206b3ccf-b520-453e-af90-2b0f6f09743a.png">](https://www.linkedin.com/in/michaelalfan0/) &nbsp;&nbsp; [<img alt="Gmail Icon" height="30" src="https://user-images.githubusercontent.com/59615799/163060515-68f51255-4d3f-4af8-8fec-3ea14bb17740.png">](mailto:michaelalfano2004@gmail.com)


### PR DESCRIPTION
The links to Lure Cast and Ripple had no scheme, and so were treated as relative paths instead of absolute URLs.